### PR TITLE
Update GitLab to 8.11.5 to get all the latest features and bug fixes

### DIFF
--- a/repo/packages/G/gitlab/0/package.json
+++ b/repo/packages/G/gitlab/0/package.json
@@ -1,7 +1,7 @@
 {
   "packagingVersion": "3.0",
   "name": "gitlab",
-  "version": "1.0-8.10.3",
+  "version": "1.0-8.11.5",
   "minDcosReleaseVersion" : "1.8",
   "scm": "https://gitlab.com/gitlab-org/gitlab-ce",
   "maintainer": "support@gitlab.com",

--- a/repo/packages/G/gitlab/0/resource.json
+++ b/repo/packages/G/gitlab/0/resource.json
@@ -7,8 +7,8 @@
   "assets": {
     "container": {
       "docker": {
-        "gitlab-ce": "gitlab/gitlab-ce:8.10.3-ce.0",
-        "gitlab-ee": "gitlab/gitlab-ee:8.10.3-ee.0"
+        "gitlab-ce": "gitlab/gitlab-ce:8.11.5-ce.0",
+        "gitlab-ee": "gitlab/gitlab-ee:8.11.5-ee.0"
       }
     }
   }


### PR DESCRIPTION
@ssk2  This includes the latest patched release of GitLab 8.11.5  I did a quick smoke test to make sure both the CE and EE version installed correctly in DC/OS, but haven't tested any deeper.
